### PR TITLE
Issue #30: Verify roe-specific chemicals (DDT, gamma-HCH, Permethrin) with Michelle

### DIFF
--- a/scripts/Clean_the_roe_deer_data.R
+++ b/scripts/Clean_the_roe_deer_data.R
@@ -101,9 +101,9 @@ raw_data <- purrr::reduce(
     "Propiconazole" = "Propiconazole* [µg kg-1]",
     "Tebuconazole" = "Tebuconazole [µg kg-1]",
     "Tetraconazole" = "Tetraconazole [µg kg-1]",
-    # IMPORTANT
     # The following chemicals are not in the overview of the original data.
-    # Does it mean that they were not discovered, or not measured at all?
+    # It means that they were measured there too, but not discovered in a single
+    # sample.
     "gamma-HCH" = "gamma-HCH (Lindane) [µg kg-1]",
     "Permethrin" = "Permethrin [µg kg-1]",
     "DDT (p,p' and o,p')" = "DDT (p,p' and o,p') [µg kg-1]",

--- a/scripts/Process_the_data.R
+++ b/scripts/Process_the_data.R
@@ -18,8 +18,8 @@ dat_roe <- read_csv("data/clean_roe_deer_data.csv") |>
 chem_categories_deer <- chem_categories |>
   filter(Chemical %in% colnames(dat_roe))
 
-# Chemicals measured only for the roe deer samples.
-# Let Michelle check that we indeed do not have these in the main data.
+# Chemicals discovered only for the roe deer samples. They were not discovered
+# in any samples in the main deer data, but they were indeed looked for.
 chem_categories_roe <- tibble(
   Chemical = c("DDT (p,p' and o,p')", "gamma-HCH", "Permethrin"),
   primary_category = c("POP", "POP", "Pesticide"),
@@ -29,7 +29,9 @@ chem_categories_roe <- tibble(
 # The subset of chemicals measured for both datasets
 chem_categories_subset <- rbind(chem_categories_deer, chem_categories_roe)
 
-# Combine both datasets
+# Combine both datasets. bind_rows() introduces NA values for columns, that
+# does not appear in both data frames. This is exactly what we want, because the
+# NA values represent substances, that were not discovered in a sample.
 dat <- bind_rows(dat_deer, dat_roe) |>
   select(
     c(


### PR DESCRIPTION
This PR closes #30. We verified, that

- DDT (p,p' and o,p')
- gamma-HCH
- Permethrin

for which we have entries in the roe deer data, but not in the main deer data, were indeed looked for in the main data too, but were not discovered for any samples.

This effectively expands the set of substances, we carry the analysis for. This is discussed in Issue https://github.com/barbora-sobolova/wildlife_pollution_analysis/issues/22#issuecomment-3187193454, so we won't delve into this question here.